### PR TITLE
Adds async/await support to WebView RPC framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2025-06-23
+
+### Added
+- Full async/await support for both server and client implementations
+- `asyncMethodHandlers` dictionary in `ServiceDefinition` for async method registration
+- Async method handling in `WebViewRpcServer` with automatic fallback to sync handlers
+- Virtual-Virtual pattern in code generation templates for backward compatibility
+
+### Changed
+- **BREAKING**: Generated server methods now use async pattern by default
+  - C# servers must implement `UniTask<Response> MethodNameAsync(Request request)`
+  - JavaScript servers must implement `async MethodNameAsync(request)`
+- **BREAKING**: Generated client methods now have `Async` suffix
+  - C# clients call `await client.MethodNameAsync(request)`
+  - JavaScript clients call `await client.MethodNameAsync(request)`
+- WebViewRpcServer now processes async handlers first, then falls back to sync handlers
+
+### Migration Guide
+
+#### For C# Server Implementations
+
+**Before (v0.x):**
+```csharp
+public class MyService : MyServiceBase
+{
+    public override Response MyMethod(Request request)
+    {
+        // Synchronous implementation
+        return new Response { ... };
+    }
+}
+```
+
+**After (v1.0):**
+```csharp
+public class MyService : MyServiceBase
+{
+    public override async UniTask<Response> MyMethodAsync(Request request)
+    {
+        // Asynchronous implementation
+        await UniTask.Delay(100);
+        return new Response { ... };
+    }
+}
+```
+
+#### For JavaScript Server Implementations
+
+**Before (v0.x):**
+```javascript
+class MyService extends MyServiceBase {
+    MyMethod(request) {
+        // Synchronous implementation
+        return { ... };
+    }
+}
+```
+
+**After (v1.0):**
+```javascript
+class MyService extends MyServiceBase {
+    async MyMethodAsync(request) {
+        // Asynchronous implementation
+        await someAsyncOperation();
+        return { ... };
+    }
+}
+```
+
+#### For Client Code
+
+**Before (v0.x):**
+```csharp
+var response = await client.MyMethod(request);
+```
+
+**After (v1.0):**
+```csharp
+var response = await client.MyMethodAsync(request);
+```
+
+### Backward Compatibility
+
+The library maintains backward compatibility through the Virtual-Virtual pattern:
+- Existing synchronous implementations will continue to work
+- You can gradually migrate methods to async as needed
+- The server automatically handles both sync and async methods
+
+## [0.1.1] - Previous version
+- Initial release with basic RPC functionality 

--- a/Packages/WebviewRpc/Runtime/ServiceDefinition.cs
+++ b/Packages/WebviewRpc/Runtime/ServiceDefinition.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
 using Google.Protobuf;
 
 namespace WebViewRPC
@@ -11,5 +12,8 @@ namespace WebViewRPC
     {
         public Dictionary<string, Func<ByteString, ByteString>> MethodHandlers
             = new Dictionary<string, Func<ByteString, ByteString>>();
+            
+        public Dictionary<string, Func<ByteString, UniTask<ByteString>>> AsyncMethodHandlers
+            = new Dictionary<string, Func<ByteString, UniTask<ByteString>>>();
     }
 }

--- a/Packages/WebviewRpc/package.json
+++ b/Packages/WebviewRpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.kwanjoong.webviewrpc",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "displayName": "Webview RPC",
   "description": "The webview Remote Procedure Call bridge.",
   "unity": "2022.3",

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ npm install
 npm run build
 ```
 
+## What's New in v1.0.0
+
+### Full Async/Await Support
+WebView RPC now supports full async/await patterns for both server and client implementations:
+
+- **C# Integration**: Uses `UniTask` for better Unity performance
+- **JavaScript Integration**: Native `async/await` support
+- **Backward Compatibility**: Existing synchronous code continues to work through the Virtual-Virtual pattern
+
+### Breaking Changes
+- Generated methods now have `Async` suffix (e.g., `SayHelloAsync`)
+- Server implementations must use async patterns
+
+For detailed migration guide, see [CHANGELOG.md](CHANGELOG.md).
+
 ## Installation
 
 ### Adding WebView RPC to a Unity Project
@@ -373,18 +388,23 @@ public class WebViewRpcTester : MonoBehaviour
 ```
 
 ```csharp
+using Cysharp.Threading.Tasks;
 using HelloWorld;
 using UnityEngine;
 
 namespace SampleRpc
 {
-    // Inherit HelloWorldService and implement the SayHello method.
-    // HelloWorldService is generated from HelloWorld.proto.
+    // Inherit HelloServiceBase and implement the SayHelloAsync method.
+    // HelloServiceBase is generated from HelloWorld.proto.
     public class HelloWorldService : HelloServiceBase
     {
-        public override HelloResponse SayHello(HelloRequest request)
+        public override async UniTask<HelloResponse> SayHelloAsync(HelloRequest request)
         {
             Debug.Log($"Received request: {request.Name}");
+            
+            // Example async operation
+            await UniTask.Delay(100);
+            
             return new HelloResponse()
             {
                 // Process the request and return a response
@@ -408,7 +428,8 @@ document.getElementById('btnSayHello').addEventListener('click', async () => {
         const reqObj = { name: "Hello World! From WebView" };
         console.log("Request to Unity: ", reqObj);
 
-        const resp = await helloClient.SayHello(reqObj);
+        // Note: Method now has Async suffix
+        const resp = await helloClient.SayHelloAsync(reqObj);
         console.log("Response from Unity: ", resp.greeting);
     } catch (err) {
         console.error("Error: ", err);
@@ -467,8 +488,8 @@ public class WebViewRpcTester : MonoBehaviour
         // Create a HelloServiceClient
         var client = new HelloServiceClient(rpcClient);
 
-        // Send a request
-        var response = await client.SayHello(new HelloRequest()
+        // Send a request (note the Async suffix)
+        var response = await client.SayHelloAsync(new HelloRequest()
         {
             Name = "World"
         });
@@ -508,9 +529,12 @@ import { HelloServiceBase } from "./HelloWorld_HelloServiceBase.js";
 
 // Inherit HelloServiceBase from the auto-generated HelloWorld_HelloServiceBase.js
 export class MyHelloServiceImpl extends HelloServiceBase {
-    SayHello(requestObj) {
+    async SayHelloAsync(requestObj) {
         // Check the incoming request
         console.log("JS Server received: ", requestObj);
+        
+        // Example async operation
+        await new Promise(resolve => setTimeout(resolve, 100));
 
         // Process the request and return a response
         return {

--- a/README_ko.md
+++ b/README_ko.md
@@ -67,6 +67,21 @@ npm install
 npm run build
 ```
 
+## v1.0.0의 새로운 기능
+
+### 완전한 Async/Await 지원
+WebView RPC는 이제 서버 및 클라이언트 구현 모두에 대해 완전한 async/await 패턴을 지원합니다:
+
+- **C# 통합**: Unity 성능 향상을 위한 `UniTask` 사용
+- **JavaScript 통합**: 네이티브 `async/await` 지원
+- **하위 호환성**: Virtual-Virtual 패턴을 통해 기존 동기 코드가 계속 작동
+
+### 주요 변경사항
+- 생성된 메서드에 이제 `Async` 접미사가 붙습니다 (예: `SayHelloAsync`)
+- 서버 구현은 비동기 패턴을 사용해야 합니다
+
+자세한 마이그레이션 가이드는 [CHANGELOG.md](CHANGELOG.md)를 참조하세요.
+
 ## 설치
 ### 유니티 프로젝트에 WebView RPC 추가하기
 1. Nuget 패키지 매니저를 통해 `Protobuf` 패키지를 설치합니다.
@@ -341,18 +356,23 @@ public class WebViewRpcTester : MonoBehaviour
 }
 ```
 ```csharp
+using Cysharp.Threading.Tasks;
 using HelloWorld;
 using UnityEngine;
 
 namespace SampleRpc
 {
-    // HelloWorldService를 상속받아 SayHello 메서드를 구현
-    // HelloWorldService는 HelloWorld.proto에서 생성된 코드입니다.
+    // HelloServiceBase를 상속받아 SayHelloAsync 메서드를 구현
+    // HelloServiceBase는 HelloWorld.proto에서 생성된 코드입니다.
     public class HelloWorldService : HelloServiceBase
     {
-        public override HelloResponse SayHello(HelloRequest request)
+        public override async UniTask<HelloResponse> SayHelloAsync(HelloRequest request)
         {
             Debug.Log($"Received request: {request.Name}");
+            
+            // 비동기 작업 예시
+            await UniTask.Delay(100);
+            
             return new HelloResponse()
             {
                 // 요청을 받아 응답을 반환
@@ -375,7 +395,8 @@ document.getElementById('btnSayHello').addEventListener('click', async () => {
         const reqObj = {name: "Hello World! From WebView"};
         console.log("Request to Unity: ", reqObj);
 
-        const resp = await helloClient.SayHello(reqObj);
+        // 참고: 메서드에 이제 Async 접미사가 붙습니다
+        const resp = await helloClient.SayHelloAsync(reqObj);
         console.log("Response from Unity: ", resp.greeting);
     } catch (err) {
         console.error("Error: ", err);
@@ -427,8 +448,8 @@ public class WebViewRpcTester : MonoBehaviour
         // HelloServiceClient 생성
         var client = new HelloServiceClient(rpcClient);
         
-        // 요청 보내기
-        var response = await client.SayHello(new HelloRequest()
+        // 요청 보내기 (Async 접미사 주의)
+        var response = await client.SayHelloAsync(new HelloRequest()
         {
             Name = "World"
         });
@@ -466,9 +487,12 @@ import { HelloServiceBase } from "./HelloWorld_HelloServiceBase.js";
 
 // 자동 생성된 HelloWorld_HelloServiceBase.js의 HelloServiceBase를 상속받아 구현
 export class MyHelloServiceImpl extends HelloServiceBase {
-    SayHello(requestObj) {
+    async SayHelloAsync(requestObj) {
         // 받은 요청을 확인
         console.log("JS Server received: ", requestObj);
+        
+        // 비동기 작업 예시
+        await new Promise(resolve => setTimeout(resolve, 100));
         
         // 요청을 받아 응답을 반환
         return { greeting: "Hello from JS! I got your message: " + requestObj.name };

--- a/webview_rpc_runtime_library/CHANGELOG.md
+++ b/webview_rpc_runtime_library/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2025-06-23
+
+### Added
+- Full async/await support for both server and client implementations
+- `asyncMethodHandlers` dictionary in `ServiceDefinition` for async method registration
+- Async method handling in `WebViewRpcServer` with automatic fallback to sync handlers
+- Virtual-Virtual pattern in code generation templates for backward compatibility
+
+### Changed
+- **BREAKING**: Generated server methods now use async pattern by default
+  - C# servers must implement `UniTask<Response> MethodNameAsync(Request request)`
+  - JavaScript servers must implement `async MethodNameAsync(request)`
+- **BREAKING**: Generated client methods now have `Async` suffix
+  - C# clients call `await client.MethodNameAsync(request)`
+  - JavaScript clients call `await client.MethodNameAsync(request)`
+- WebViewRpcServer now processes async handlers first, then falls back to sync handlers
+
+### Migration Guide
+
+#### For C# Server Implementations
+
+**Before (v0.x):**
+```csharp
+public class MyService : MyServiceBase
+{
+    public override Response MyMethod(Request request)
+    {
+        // Synchronous implementation
+        return new Response { ... };
+    }
+}
+```
+
+**After (v1.0):**
+```csharp
+public class MyService : MyServiceBase
+{
+    public override async UniTask<Response> MyMethodAsync(Request request)
+    {
+        // Asynchronous implementation
+        await UniTask.Delay(100);
+        return new Response { ... };
+    }
+}
+```
+
+#### For JavaScript Server Implementations
+
+**Before (v0.x):**
+```javascript
+class MyService extends MyServiceBase {
+    MyMethod(request) {
+        // Synchronous implementation
+        return { ... };
+    }
+}
+```
+
+**After (v1.0):**
+```javascript
+class MyService extends MyServiceBase {
+    async MyMethodAsync(request) {
+        // Asynchronous implementation
+        await someAsyncOperation();
+        return { ... };
+    }
+}
+```
+
+#### For Client Code
+
+**Before (v0.x):**
+```csharp
+var response = await client.MyMethod(request);
+```
+
+**After (v1.0):**
+```csharp
+var response = await client.MyMethodAsync(request);
+```
+
+### Backward Compatibility
+
+The library maintains backward compatibility through the Virtual-Virtual pattern:
+- Existing synchronous implementations will continue to work
+- You can gradually migrate methods to async as needed
+- The server automatically handles both sync and async methods
+
+## [0.1.1] - Previous version
+- Initial release with basic RPC functionality 

--- a/webview_rpc_runtime_library/package-lock.json
+++ b/webview_rpc_runtime_library/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-webview-rpc",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-webview-rpc",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "rimraf": "^5.0.0",

--- a/webview_rpc_runtime_library/package.json
+++ b/webview_rpc_runtime_library/package.json
@@ -13,7 +13,10 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "README.md",
+    "README_ko.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rimraf dist && npm run build:esm && npm run build:cjs",

--- a/webview_rpc_runtime_library/package.json
+++ b/webview_rpc_runtime_library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-webview-rpc",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "type": "module",
   "description": "WebView RPC provides an abstraction layer that allows communication between the App (e.g. Unity C#) and WebView (HTML, JS) using protobuf, similar to gRPC.",
   "main": "./dist/cjs/index.js",

--- a/webview_rpc_runtime_library/src/core/service_definition.js
+++ b/webview_rpc_runtime_library/src/core/service_definition.js
@@ -3,6 +3,10 @@ export class ServiceDefinition {
       // methodName -> handlerFn
       // handlerFn: (requestBytes: Uint8Array) => Uint8Array
       this.methodHandlers = {};
+      
+      // methodName -> asyncHandlerFn
+      // asyncHandlerFn: (requestBytes: Uint8Array) => Promise<Uint8Array>
+      this.asyncMethodHandlers = {};
     }
   }
   


### PR DESCRIPTION
Enhances the WebView RPC framework with full async/await functionality:
- Introduces UniTask for C# to improve performance and maintains backward compatibility
- Updates JavaScript runtime for native async/await support
- Modifies method signature for generated server and client methods with an `Async` suffix

Includes a detailed migration guide and updates to the documentation to assist users in transitioning to the new async pattern.