### PR TITLE
fix: Add missing UniTask reference in Runtime.asmdef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-06-23
+
+### Fixed
+- Added missing UniTask reference in Runtime.asmdef
+- This fixes compilation errors when using the package
+
 ## [1.0.1] - 2025-06-23
 
 ### Changed

--- a/Packages/WebviewRpc/Runtime/Runtime.asmdef
+++ b/Packages/WebviewRpc/Runtime/Runtime.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "Runtime",
     "rootNamespace": "WebviewRpc",
-    "references": [],
+    "references": [
+        "UniTask"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,

--- a/Packages/WebviewRpc/package.json
+++ b/Packages/WebviewRpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.kwanjoong.webviewrpc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "displayName": "Webview RPC",
   "description": "The webview Remote Procedure Call bridge.",
   "unity": "2022.3",


### PR DESCRIPTION
- Fixes compilation errors when using WebViewRpc
- Update version to 1.0.2
