### PR TITLE
Updates package version to 2.0.1 for error handling tweak

### DIFF
--- a/Packages/WebviewRpc/Runtime/WebViewRpcClient.cs
+++ b/Packages/WebviewRpc/Runtime/WebViewRpcClient.cs
@@ -141,9 +141,14 @@ namespace WebViewRPC
                             RequestId = envelope.RequestId,
                             IsRequest = envelope.IsRequest,
                             Method = envelope.Method,
-                            Payload = ByteString.CopyFrom(completeData),
-                            Error = envelope.Error
+                            Payload = ByteString.CopyFrom(completeData)
                         };
+                        
+                        // Only set Error if it's not null or empty
+                        if (!string.IsNullOrEmpty(envelope.Error))
+                        {
+                            completeEnvelope.Error = envelope.Error;
+                        }
                         
                         ProcessCompleteEnvelope(completeEnvelope);
                     }

--- a/Packages/WebviewRpc/Runtime/WebViewRpcServer.cs
+++ b/Packages/WebviewRpc/Runtime/WebViewRpcServer.cs
@@ -61,9 +61,14 @@ namespace WebViewRPC
                             RequestId = envelope.RequestId,
                             IsRequest = envelope.IsRequest,
                             Method = envelope.Method,
-                            Payload = ByteString.CopyFrom(completeData),
-                            Error = envelope.Error
+                            Payload = ByteString.CopyFrom(completeData)
                         };
+                        
+                        // Only set Error if it's not null or empty
+                        if (!string.IsNullOrEmpty(envelope.Error))
+                        {
+                            completeEnvelope.Error = envelope.Error;
+                        }
                         
                         if (completeEnvelope.IsRequest)
                         {
@@ -129,9 +134,14 @@ namespace WebViewRPC
                         RequestId = requestEnvelope.RequestId,
                         IsRequest = false,
                         Method = requestEnvelope.Method,
-                        Payload = responsePayload,
-                        Error = error
+                        Payload = responsePayload
                     };
+                    
+                    // Only set Error if it's not null or empty
+                    if (!string.IsNullOrEmpty(error))
+                    {
+                        responseEnvelope.Error = error;
+                    }
                     
                     var bytes = responseEnvelope.ToByteArray();
                     var base64 = Convert.ToBase64String(bytes);

--- a/Packages/WebviewRpc/package.json
+++ b/Packages/WebviewRpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.kwanjoong.webviewrpc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "displayName": "Webview RPC",
   "description": "The webview Remote Procedure Call bridge.",
   "unity": "2022.3",


### PR DESCRIPTION
Bumps the package version to reflect a minor update that ensures the error field is only set when non-null or not empty.

Helps avoid unnecessary error information in responses and signals improved robustness of error handling.

Relates to improved reliability and downstream consistency.