### PR TITLE
Fixes chunk reassembly timeouts and improves RPC disposal

### DIFF
--- a/Assets/SampleRpc/ViewplexWebViewBridge.cs
+++ b/Assets/SampleRpc/ViewplexWebViewBridge.cs
@@ -4,24 +4,50 @@ using WebViewRPC;
 
 namespace SampleRpc
 {
-    public class ViewplexWebViewBridge : IWebViewBridge
+    public class ViewplexWebViewBridge : IWebViewBridge, IDisposable
     {
         public event Action<string> OnMessageReceived;
         private readonly CanvasWebViewPrefab _webViewPrefab;
-    
+        private bool _disposed;
+        
         public ViewplexWebViewBridge(CanvasWebViewPrefab webViewPrefab)
         {
             _webViewPrefab = webViewPrefab;
-        
-            _webViewPrefab.WebView.MessageEmitted += (sender, args) =>
-            {
-                OnMessageReceived?.Invoke(args.Value);
-            };
+            
+            // Store handler for proper cleanup
+            _webViewPrefab.WebView.MessageEmitted += OnWebViewMessageEmitted;
         }
-    
+        
+        private void OnWebViewMessageEmitted(object sender, EventArgs<string> args)
+        {
+            OnMessageReceived?.Invoke(args.Value);
+        }
+        
         public void SendMessageToWeb(string message)
         {
+            if (_disposed || _webViewPrefab == null || _webViewPrefab.WebView == null)
+            {
+                // WebView is already destroyed, don't send message
+                return;
+            }
+            
             _webViewPrefab.WebView.PostMessage(message);
+        }
+        
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                
+                // Unsubscribe from WebView events
+                if (_webViewPrefab != null && _webViewPrefab.WebView != null)
+                {
+                    _webViewPrefab.WebView.MessageEmitted -= OnWebViewMessageEmitted;
+                }
+                
+                OnMessageReceived = null;
+            }
         }
     }
 }

--- a/Assets/SampleRpc/ViewplexWebViewBridge.cs
+++ b/Assets/SampleRpc/ViewplexWebViewBridge.cs
@@ -4,7 +4,7 @@ using WebViewRPC;
 
 namespace SampleRpc
 {
-    public class ViewplexWebViewBridge : IWebViewBridge, IDisposable
+    public class ViewplexWebViewBridge : IWebViewBridge
     {
         public event Action<string> OnMessageReceived;
         private readonly CanvasWebViewPrefab _webViewPrefab;

--- a/Assets/SampleRpc/ViewplexWebViewBridge.cs
+++ b/Assets/SampleRpc/ViewplexWebViewBridge.cs
@@ -9,6 +9,7 @@ namespace SampleRpc
         public event Action<string> OnMessageReceived;
         private readonly CanvasWebViewPrefab _webViewPrefab;
         private bool _disposed;
+        private bool _webViewDestroyed;
         
         public ViewplexWebViewBridge(CanvasWebViewPrefab webViewPrefab)
         {
@@ -16,22 +17,46 @@ namespace SampleRpc
             
             // Store handler for proper cleanup
             _webViewPrefab.WebView.MessageEmitted += OnWebViewMessageEmitted;
+            
+            // WebView의 파괴를 감지하기 위한 이벤트 등록
+            // if (_webViewPrefab.WebView is IWebView webView)
+            // {
+            //     webView.Disposed += OnWebViewDisposed;
+            // }
+        }
+        
+        private void OnWebViewDisposed(object sender, EventArgs args)
+        {
+            _webViewDestroyed = true;
         }
         
         private void OnWebViewMessageEmitted(object sender, EventArgs<string> args)
         {
+            // WebView가 파괴된 후에는 메시지를 처리하지 않음
+            if (_disposed || _webViewDestroyed) return;
+            
             OnMessageReceived?.Invoke(args.Value);
         }
         
         public void SendMessageToWeb(string message)
         {
-            if (_disposed || _webViewPrefab == null || _webViewPrefab.WebView == null)
+            // WebView가 파괴되었거나 dispose된 경우 메시지를 보내지 않음
+            if (_disposed || _webViewDestroyed || _webViewPrefab == null || _webViewPrefab.WebView == null)
             {
-                // WebView is already destroyed, don't send message
+                // 디버그 로그로 확인 (필요시 주석 처리)
+                // UnityEngine.Debug.Log("[ViewplexWebViewBridge] Message dropped - WebView is destroyed");
                 return;
             }
             
-            _webViewPrefab.WebView.PostMessage(message);
+            try
+            {
+                _webViewPrefab.WebView.PostMessage(message);
+            }
+            catch (Exception ex)
+            {
+                // WebView가 이미 파괴된 경우 예외 처리
+                UnityEngine.Debug.LogWarning($"[ViewplexWebViewBridge] Failed to send message: {ex.Message}");
+            }
         }
         
         public void Dispose()
@@ -44,6 +69,11 @@ namespace SampleRpc
                 if (_webViewPrefab != null && _webViewPrefab.WebView != null)
                 {
                     _webViewPrefab.WebView.MessageEmitted -= OnWebViewMessageEmitted;
+                    
+                    // if (_webViewPrefab.WebView is IWebView webView)
+                    // {
+                    //     webView.Disposed -= OnWebViewDisposed;
+                    // }
                 }
                 
                 OnMessageReceived = null;

--- a/Assets/SampleRpc/WebViewRpcTester.cs
+++ b/Assets/SampleRpc/WebViewRpcTester.cs
@@ -56,10 +56,6 @@ namespace SampleRpc
             // Initialize C# Client to handle C# -> JS RPC
             _rpcClient = new WebViewRpcClient(_bridge);
             _client = new HelloServiceClient(_rpcClient);
-        
-            // Run bidirectional test
-            await UniTask.Delay(3000); // Wait for web to be ready
-            // RunBidirectionalChunkingTest();
         }
 
         private async void RunBidirectionalChunkingTest()

--- a/Assets/SampleRpc/WebViewRpcTester.cs
+++ b/Assets/SampleRpc/WebViewRpcTester.cs
@@ -174,7 +174,11 @@ namespace SampleRpc
         {
             Debug.Log("[WebViewRpcTester] OnDestroy - Cleaning up RPC components");
             
-            // Dispose in reverse order of creation
+            // WebView가 이미 파괴되었을 수 있으므로, 먼저 Bridge를 dispose
+            _bridge?.Dispose();
+            _bridge = null;
+            
+            // 그 다음 RPC 컴포넌트들을 정리
             _client = null;
             
             _rpcClient?.Dispose();
@@ -182,10 +186,6 @@ namespace SampleRpc
             
             _server?.Dispose();
             _server = null;
-            
-            // Dispose the bridge last
-            _bridge?.Dispose();
-            _bridge = null;
             
             Debug.Log("[WebViewRpcTester] OnDestroy - Cleanup complete");
         }

--- a/Packages/WebviewRpc/Runtime/ChunkAssembler.cs
+++ b/Packages/WebviewRpc/Runtime/ChunkAssembler.cs
@@ -18,10 +18,10 @@ namespace WebViewRPC
             public DateTime LastActivity { get; set; }
             public string RequestId { get; set; }
         }
-        
+
         private readonly Dictionary<string, ChunkSet> _chunkSets = new();
         private readonly object _lock = new object();
-        
+
         /// <summary>
         /// Try to reassemble chunks. Returns null if not all chunks received yet.
         /// </summary>
@@ -29,26 +29,26 @@ namespace WebViewRPC
         {
             return TryAssemble(envelope, out _);
         }
-        
+
         /// <summary>
         /// Try to reassemble chunks. Returns null if not all chunks received yet.
         /// </summary>
         public byte[] TryAssemble(RpcEnvelope envelope, out List<string> timedOutRequestIds)
         {
             timedOutRequestIds = new List<string>();
-            
+
             if (envelope.ChunkInfo == null)
             {
                 // Not a chunked message
                 return envelope.Payload.ToByteArray();
             }
-            
+
             lock (_lock)
             {
                 var chunkInfo = envelope.ChunkInfo;
-                
+
                 // Check if we've reached the maximum number of chunk sets
-                if (!_chunkSets.ContainsKey(chunkInfo.ChunkSetId) && 
+                if (!_chunkSets.ContainsKey(chunkInfo.ChunkSetId) &&
                     _chunkSets.Count >= WebViewRpcConfiguration.MaxConcurrentChunkSets)
                 {
                     // Remove the oldest chunk set
@@ -57,9 +57,10 @@ namespace WebViewRPC
                         .First()
                         .Key;
                     _chunkSets.Remove(oldestKey);
-                    Debug.LogWarning($"Maximum chunk sets reached ({WebViewRpcConfiguration.MaxConcurrentChunkSets}). Removed oldest chunk set {oldestKey}");
+                    Debug.LogWarning(
+                        $"Maximum chunk sets reached ({WebViewRpcConfiguration.MaxConcurrentChunkSets}). Removed oldest chunk set {oldestKey}");
                 }
-                
+
                 if (!_chunkSets.TryGetValue(chunkInfo.ChunkSetId, out var chunkSet))
                 {
                     chunkSet = new ChunkSet
@@ -71,18 +72,18 @@ namespace WebViewRPC
                     };
                     _chunkSets[chunkInfo.ChunkSetId] = chunkSet;
                 }
-                
+
                 // Add chunk
                 chunkSet.Chunks[chunkInfo.ChunkIndex] = envelope.Payload.ToByteArray();
                 chunkSet.LastActivity = DateTime.UtcNow;
-                
+
                 // Check if all chunks received
                 if (chunkSet.Chunks.Count == chunkSet.TotalChunks)
                 {
                     // Assemble
                     var result = new byte[chunkSet.OriginalSize];
                     var offset = 0;
-                    
+
                     for (int i = 1; i <= chunkSet.TotalChunks; i++)
                     {
                         if (!chunkSet.Chunks.TryGetValue(i, out var chunk))
@@ -90,40 +91,40 @@ namespace WebViewRPC
                             Debug.LogError($"Missing chunk {i} in set {chunkInfo.ChunkSetId}");
                             return null;
                         }
-                        
+
                         Array.Copy(chunk, 0, result, offset, chunk.Length);
                         offset += chunk.Length;
                     }
-                    
+
                     // Clean up
                     _chunkSets.Remove(chunkInfo.ChunkSetId);
-                    
+
                     // Verify size
                     if (offset != chunkSet.OriginalSize)
                     {
                         Debug.LogError($"Assembled size mismatch: expected {chunkSet.OriginalSize}, got {offset}");
                         return null;
                     }
-                    
+
                     return result;
                 }
-                
+
                 // Cleanup old chunk sets (older than configured timeout)
                 var cutoff = DateTime.UtcNow.AddSeconds(-WebViewRpcConfiguration.ChunkTimeoutSeconds);
                 var toRemove = _chunkSets
                     .Where(kvp => kvp.Value.LastActivity < cutoff)
                     .ToList();
-                
+
                 foreach (var kvp in toRemove)
                 {
                     timedOutRequestIds.Add(kvp.Value.RequestId);
                     _chunkSets.Remove(kvp.Key);
-                    Debug.LogWarning($"Removed incomplete chunk set {kvp.Key} for request {kvp.Value.RequestId} due to timeout");
+                    Debug.LogWarning(
+                        $"Removed incomplete chunk set {kvp.Key} for request {kvp.Value.RequestId} due to timeout");
                 }
-                
+
                 return null; // Not all chunks received yet
             }
         }
     }
-} 
-} 
+}

--- a/Packages/WebviewRpc/Runtime/IWebViewBridge.cs
+++ b/Packages/WebviewRpc/Runtime/IWebViewBridge.cs
@@ -7,7 +7,7 @@ namespace WebViewRPC
     /// - SendMessageToWeb: C# -> JS send string
     /// - OnMessageReceived: JS -> C# receive string
     /// </summary>
-    public interface IWebViewBridge
+    public interface IWebViewBridge : IDisposable
     {
         /// <summary>
         /// C# to WebView send string

--- a/Packages/WebviewRpc/Runtime/WebViewRpcClient.cs
+++ b/Packages/WebviewRpc/Runtime/WebViewRpcClient.cs
@@ -209,6 +209,8 @@ namespace WebViewRPC
         {
             if (!_disposed)
             {
+                _disposed = true;
+                
                 _bridge.OnMessageReceived -= OnBridgeMessage;
                 
                 // Cancel all pending requests
@@ -221,7 +223,8 @@ namespace WebViewRPC
                     _pendingRequests.Clear();
                 }
                 
-                _disposed = true;
+                // Note: Do not dispose the bridge here as it may be shared
+                // The owner of the bridge should dispose it
             }
         }
     }

--- a/Packages/WebviewRpc/Runtime/WebViewRpcConfiguration.cs
+++ b/Packages/WebviewRpc/Runtime/WebViewRpcConfiguration.cs
@@ -7,6 +7,7 @@ namespace WebViewRPC
     {
         private static int _maxChunkSize = 256 * 1024;
         private static int _chunkTimeoutSeconds = 30;
+        private static int _maxConcurrentChunkSets = 100;
         
         /// <summary>
         /// Estimated RPC envelope overhead in bytes when chunking
@@ -112,6 +113,28 @@ namespace WebViewRPC
         public static bool IsChunkSizeValid()
         {
             return GetEffectivePayloadSize() >= 100;
+        }
+        
+        /// <summary>
+        /// Maximum number of concurrent chunk sets allowed (default: 100)
+        /// This prevents memory exhaustion from too many incomplete chunk sets
+        /// Minimum: 10, Maximum: 1000
+        /// </summary>
+        public static int MaxConcurrentChunkSets
+        {
+            get => _maxConcurrentChunkSets;
+            set
+            {
+                if (value < 10)
+                {
+                    throw new System.ArgumentException($"MaxConcurrentChunkSets must be at least 10. Provided: {value}");
+                }
+                if (value > 1000)
+                {
+                    throw new System.ArgumentException($"MaxConcurrentChunkSets cannot exceed 1000. Provided: {value}");
+                }
+                _maxConcurrentChunkSets = value;
+            }
         }
     }
 } 

--- a/Packages/WebviewRpc/Runtime/WebViewRpcServer.cs
+++ b/Packages/WebviewRpc/Runtime/WebViewRpcServer.cs
@@ -230,8 +230,11 @@ namespace WebViewRPC
         {
             if (!_disposed)
             {
-                _bridge.OnMessageReceived -= OnBridgeMessage;
                 _disposed = true;
+                _bridge.OnMessageReceived -= OnBridgeMessage;
+                
+                // Note: Do not dispose the bridge here as it may be shared
+                // The owner of the bridge should dispose it
             }
         }
     }

--- a/Packages/WebviewRpc/package.json
+++ b/Packages/WebviewRpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.kwanjoong.webviewrpc",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "displayName": "Webview RPC",
   "description": "The webview Remote Procedure Call bridge.",
   "unity": "2022.3",

--- a/webview_rpc_runtime_library/CHANGELOG.md
+++ b/webview_rpc_runtime_library/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.9] - 2025-01-22
+
+### Added
+- `maxConcurrentChunkSets` configuration option (default: 100, min: 10, max: 1000)
+- Request ID tracking in ChunkAssembler for better timeout management
+- Proper timeout handling for chunk reassembly failures
+
+### Fixed
+- **Critical**: Fixed infinite waiting issue when chunk reassembly times out
+- Pending requests are now properly rejected with timeout error when chunks expire
+- Unity: Added `TimeoutException` for chunk reassembly failures
+- JavaScript: Added timeout error rejection for incomplete chunk sets
+
+### Changed
+- ChunkAssembler now returns timed out request IDs for proper cleanup
+- Both Unity and JavaScript implementations now handle chunk timeouts consistently
+
 ## [2.0.8] - 2025-01-22
 
 ### Added

--- a/webview_rpc_runtime_library/package.json
+++ b/webview_rpc_runtime_library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-webview-rpc",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "type": "module",
   "description": "WebView RPC provides an abstraction layer that allows communication between the App (e.g. Unity C#) and WebView (HTML, JS) using protobuf, similar to gRPC.",
   "main": "./dist/cjs/index.js",

--- a/webview_rpc_runtime_library/src/core/webview_rpc_configuration.js
+++ b/webview_rpc_runtime_library/src/core/webview_rpc_configuration.js
@@ -4,6 +4,7 @@
 export const WebViewRpcConfiguration = {
     _maxChunkSize: 256 * 1024,
     _chunkTimeoutSeconds: 30,
+    _maxConcurrentChunkSets: 100,
     
     /**
      * Estimated RPC envelope overhead in bytes when chunking
@@ -101,5 +102,24 @@ export const WebViewRpcConfiguration = {
      */
     isChunkSizeValid() {
         return this.getEffectivePayloadSize() >= 100;
+    },
+    
+    /**
+     * Maximum number of concurrent chunk sets allowed (default: 100)
+     * This prevents memory exhaustion from too many incomplete chunk sets
+     * Minimum: 10, Maximum: 1000
+     */
+    get maxConcurrentChunkSets() {
+        return this._maxConcurrentChunkSets;
+    },
+    
+    set maxConcurrentChunkSets(value) {
+        if (value < 10) {
+            throw new Error(`maxConcurrentChunkSets must be at least 10. Provided: ${value}`);
+        }
+        if (value > 1000) {
+            throw new Error(`maxConcurrentChunkSets cannot exceed 1000. Provided: ${value}`);
+        }
+        this._maxConcurrentChunkSets = value;
     }
 }; 

--- a/webview_rpc_runtime_library/src/core/webview_rpc_server.js
+++ b/webview_rpc_runtime_library/src/core/webview_rpc_server.js
@@ -65,7 +65,13 @@ export class WebViewRpcServer {
             // Check if this is a chunked message
             if (envelope.chunkInfo) {
                 // Try to reassemble
-                const completeData = this._chunkAssembler.tryAssemble(envelope);
+                const { data: completeData, timedOutRequestIds } = this._chunkAssembler.tryAssemble(envelope);
+                
+                // Log timed out requests (server doesn't need to handle them specifically)
+                for (const requestId of timedOutRequestIds) {
+                    console.warn(`Request ${requestId} timed out during chunk reassembly`);
+                }
+                
                 if (completeData) {
                     // Create a new envelope with the complete data
                     const completeEnvelope = {

--- a/webview_rpc_sample/package-lock.json
+++ b/webview_rpc_sample/package-lock.json
@@ -9,12 +9,21 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "app-webview-rpc": "^2.0.9"
+        "app-webview-rpc": "file:../webview_rpc_runtime_library"
       },
       "devDependencies": {
         "http-server": "^14.1.1",
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.1"
+      }
+    },
+    "../webview_rpc_runtime_library": {
+      "version": "2.0.9",
+      "license": "MIT",
+      "devDependencies": {
+        "http-server": "^14.1.1",
+        "rimraf": "^5.0.0",
+        "typescript": "^5.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -400,9 +409,8 @@
       }
     },
     "node_modules/app-webview-rpc": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/app-webview-rpc/-/app-webview-rpc-2.0.9.tgz",
-      "integrity": "sha512-suB/kaKCqN+iV8xRdYESbOTup4BIUQTfpXMCV4h2NzpZFKOp4RXa8vSOC+eTh+bZWV0YxO2LumrBk/73sk06kQ=="
+      "resolved": "../webview_rpc_runtime_library",
+      "link": true
     },
     "node_modules/async": {
       "version": "3.2.6",

--- a/webview_rpc_sample/package-lock.json
+++ b/webview_rpc_sample/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "app-webview-rpc": "^2.0.5"
+        "app-webview-rpc": "^2.0.9"
       },
       "devDependencies": {
         "http-server": "^14.1.1",
@@ -400,9 +400,9 @@
       }
     },
     "node_modules/app-webview-rpc": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/app-webview-rpc/-/app-webview-rpc-2.0.8.tgz",
-      "integrity": "sha512-vEbu4ROxZEROEqy4qwnH8p1KC3h9zKoOGTYDilKLNE8GX5Uy0Vkj/cz86dSlfb/WW7z9V+XuL3XfuRkGC4Svkw=="
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/app-webview-rpc/-/app-webview-rpc-2.0.9.tgz",
+      "integrity": "sha512-suB/kaKCqN+iV8xRdYESbOTup4BIUQTfpXMCV4h2NzpZFKOp4RXa8vSOC+eTh+bZWV0YxO2LumrBk/73sk06kQ=="
     },
     "node_modules/async": {
       "version": "3.2.6",

--- a/webview_rpc_sample/package.json
+++ b/webview_rpc_sample/package.json
@@ -17,6 +17,6 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "app-webview-rpc": "^2.0.9"
+    "app-webview-rpc": "file:../webview_rpc_runtime_library"
   }
 }

--- a/webview_rpc_sample/package.json
+++ b/webview_rpc_sample/package.json
@@ -17,6 +17,6 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "app-webview-rpc": "^2.0.5"
+    "app-webview-rpc": "^2.0.9"
   }
 }


### PR DESCRIPTION
- Addresses critical issue where chunked RPC requests could hang indefinitely if chunk reassembly times out, by ensuring that pending requests are properly rejected with a timeout error both in Unity and JavaScript.
- Introduces configuration for limiting concurrent chunk sets to prevent memory exhaustion, with logging and error handling if limits are exceeded.
- Tracks timed out request IDs for cleanup, synchronizing logic across C# and JS implementations for consistent behavior.
- Refines disposal and lifecycle management for RPC bridges and server/client components, preventing exceptions and resource leaks when web views are destroyed.
- Updates package versions and sample app dependencies for improved local development and version tracking.

Helps prevent resource leaks, improves stability in error situations, and makes chunking logic more robust under stress.