### PR TITLE
Switches to UUID request IDs and simplifies chunk management

### DIFF
--- a/Packages/WebviewRpc/Runtime/IWebViewBridge.cs
+++ b/Packages/WebviewRpc/Runtime/IWebViewBridge.cs
@@ -12,11 +12,11 @@ namespace WebViewRPC
         /// <summary>
         /// C# to WebView send string
         /// </summary>
-        void SendMessageToWeb(string message);
+        public void SendMessageToWeb(string message);
 
         /// <summary>
         /// JS to C# receive string
         /// </summary>
-        event Action<string> OnMessageReceived;
+        public event Action<string> OnMessageReceived;
     }
 }

--- a/Packages/WebviewRpc/Runtime/WebViewRpcClient.cs
+++ b/Packages/WebviewRpc/Runtime/WebViewRpcClient.cs
@@ -15,10 +15,12 @@ namespace WebViewRPC
         private readonly IWebViewBridge _bridge;
         private readonly Dictionary<string, UniTaskCompletionSource<RpcEnvelope>> _pendingRequests = new();
         private readonly ChunkAssembler _chunkAssembler = new();
-        private int _requestIdCounter = 1;
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
         private readonly object _pendingRequestsLock = new object();
+        
+        private int _requestIdCounter = 1;
         private bool _disposed;
-        private CancellationTokenSource _cancellationTokenSource = new();
+
 
         public WebViewRpcClient(IWebViewBridge bridge)
         {

--- a/Packages/WebviewRpc/Runtime/WebViewRpcClient.cs
+++ b/Packages/WebviewRpc/Runtime/WebViewRpcClient.cs
@@ -12,14 +12,14 @@ namespace WebViewRPC
     /// </summary>
     public class WebViewRpcClient : IDisposable
     {
+        private int _requestIdCounter = 1;
+        private bool _disposed;
+        
         private readonly IWebViewBridge _bridge;
         private readonly Dictionary<string, UniTaskCompletionSource<RpcEnvelope>> _pendingRequests = new();
         private readonly ChunkAssembler _chunkAssembler = new();
         private readonly CancellationTokenSource _cancellationTokenSource = new();
         private readonly object _pendingRequestsLock = new object();
-        
-        private int _requestIdCounter = 1;
-        private bool _disposed;
 
 
         public WebViewRpcClient(IWebViewBridge bridge)

--- a/Packages/WebviewRpc/Runtime/WebViewRpcServer.cs
+++ b/Packages/WebviewRpc/Runtime/WebViewRpcServer.cs
@@ -9,10 +9,11 @@ namespace WebViewRPC
 {
     public class WebViewRpcServer : IDisposable
     {
+        private bool _disposed;
+        
         private readonly IWebViewBridge _bridge;
         private readonly ChunkAssembler _chunkAssembler = new();
-        private bool _disposed;
-        private CancellationTokenSource _cancellationTokenSource = new();
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
 
         /// <summary>
         /// You can add multiple services to the server.

--- a/Packages/WebviewRpc/Runtime/WebViewRpcServer.cs
+++ b/Packages/WebviewRpc/Runtime/WebViewRpcServer.cs
@@ -203,7 +203,6 @@ namespace WebViewRPC
             // Check disposed state before starting
             if (_disposed || cancellationToken.IsCancellationRequested) return;
             
-            var chunkSetId = $"{requestId}_{Guid.NewGuid():N}";
             int effectivePayloadSize = WebViewRpcConfiguration.GetEffectivePayloadSize();
             var totalChunks = (int)Math.Ceiling((double)data.Length / effectivePayloadSize);
             
@@ -225,7 +224,7 @@ namespace WebViewRPC
                     Payload = ByteString.CopyFrom(chunkData),
                     ChunkInfo = new ChunkInfo
                     {
-                        ChunkSetId = chunkSetId,
+                        ChunkSetId = "",
                         ChunkIndex = i,
                         TotalChunks = totalChunks,
                         OriginalSize = data.Length

--- a/Packages/WebviewRpc/package.json
+++ b/Packages/WebviewRpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.kwanjoong.webviewrpc",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "displayName": "Webview RPC",
   "description": "The webview Remote Procedure Call bridge.",
   "unity": "2022.3",
@@ -20,7 +20,7 @@
     "url": "https://github.com/kwan3854/Unity-WebviewRpc.git"
   },
   "dependencies": {
-
+    "com.cysharp.unitask": "2.5.10"
   },
   "license": "MIT"
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -18,7 +18,9 @@
       "version": "file:WebviewRpc",
       "depth": 0,
       "source": "embedded",
-      "dependencies": {}
+      "dependencies": {
+        "com.cysharp.unitask": "2.5.10"
+      }
     },
     "com.unity.ai.navigation": {
       "version": "2.0.5",

--- a/webview_rpc_runtime_library/CHANGELOG.md
+++ b/webview_rpc_runtime_library/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.11] - 2025-07-01
+### Fixed
+- Corrected release dates in CHANGELOG.md
+
 ## [2.0.10] - 2025-07-01
 ### Changed
 - **BREAKING**: RequestId generation changed from incremental integer to UUID/GUID for true uniqueness across multiple WebView instances

--- a/webview_rpc_runtime_library/CHANGELOG.md
+++ b/webview_rpc_runtime_library/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.9] - 2025-01-22
+## [2.0.10] - 2025-07-01
+### Changed
+- **BREAKING**: RequestId generation changed from incremental integer to UUID/GUID for true uniqueness across multiple WebView instances
+- Simplified chunk management by removing ChunkSetId dependency and using RequestId directly
+- Improved performance by eliminating unnecessary string concatenation operations
+- ChunkAssembler now manages chunks by RequestId instead of ChunkSetId
+
+### Fixed
+- Fixed potential RequestId collisions when multiple WebView instances are used simultaneously
+
+## [2.0.9] - 2025-06-30
 
 ### Added
 - `maxConcurrentChunkSets` configuration option (default: 100, min: 10, max: 1000)
@@ -22,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ChunkAssembler now returns timed out request IDs for proper cleanup
 - Both Unity and JavaScript implementations now handle chunk timeouts consistently
 
-## [2.0.8] - 2025-01-22
+## [2.0.8] - 2025-06-30
 
 ### Added
 - Proper dispose pattern for JavaScript components
@@ -41,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Memory leaks from unremoved event listeners
 - Potential resource leaks when page navigates away
 
-## [2.0.7] - 2025-01-22
+## [2.0.7] - 2025-06-30
 
 ### Fixed
 - Improved error handling: errors now take precedence over payload
@@ -52,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error responses can now include payload data if available
 - Clearer error messages when methods return null without setting an error
 
-## [2.0.6] - 2025-01-22
+## [2.0.6] - 2025-06-30
 
 ### Added
 - Smart chunk size calculation that accounts for RPC envelope and Base64 encoding overhead

--- a/webview_rpc_runtime_library/package.json
+++ b/webview_rpc_runtime_library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-webview-rpc",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "type": "module",
   "description": "WebView RPC provides an abstraction layer that allows communication between the App (e.g. Unity C#) and WebView (HTML, JS) using protobuf, similar to gRPC.",
   "main": "./dist/cjs/index.js",

--- a/webview_rpc_runtime_library/package.json
+++ b/webview_rpc_runtime_library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-webview-rpc",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "type": "module",
   "description": "WebView RPC provides an abstraction layer that allows communication between the App (e.g. Unity C#) and WebView (HTML, JS) using protobuf, similar to gRPC.",
   "main": "./dist/cjs/index.js",

--- a/webview_rpc_runtime_library/src/core/webview_rpc_client.js
+++ b/webview_rpc_runtime_library/src/core/webview_rpc_client.js
@@ -11,7 +11,6 @@ export class WebViewRpcClient {
     constructor(bridge) {
         this._bridge = bridge;
         this._pendingRequests = new Map();
-        this._requestIdCounter = 1;
         this._disposed = false;
         this._chunkAssembler = new ChunkAssembler();
 
@@ -32,7 +31,7 @@ export class WebViewRpcClient {
             throw new Error('RpcClient is disposed');
         }
 
-        const requestId = String(this._requestIdCounter++);
+        const requestId = crypto.randomUUID();
         
         // Create promise for this request
         const promise = new Promise((resolve, reject) => {
@@ -67,7 +66,6 @@ export class WebViewRpcClient {
      * @private
      */
     async _sendChunkedMessage(requestId, method, data, isRequest) {
-        const chunkSetId = `${requestId}_${crypto.randomUUID()}`;
         const effectivePayloadSize = WebViewRpcConfiguration.getEffectivePayloadSize();
         const totalChunks = Math.ceil(data.length / effectivePayloadSize);
 
@@ -82,7 +80,7 @@ export class WebViewRpcClient {
                 method,
                 payload: chunkData,
                 chunkInfo: {
-                    chunkSetId,
+                    chunkSetId: '',
                     chunkIndex: i,
                     totalChunks,
                     originalSize: data.length

--- a/webview_rpc_runtime_library/src/core/webview_rpc_server.js
+++ b/webview_rpc_runtime_library/src/core/webview_rpc_server.js
@@ -185,7 +185,6 @@ export class WebViewRpcServer {
      * @private
      */
     async _sendChunkedMessage(requestId, method, data, isRequest, error = null) {
-        const chunkSetId = `${requestId}_${crypto.randomUUID()}`;
         const effectivePayloadSize = WebViewRpcConfiguration.getEffectivePayloadSize();
         const totalChunks = Math.ceil(data.length / effectivePayloadSize);
 
@@ -200,7 +199,7 @@ export class WebViewRpcServer {
                 method,
                 payload: chunkData,
                 chunkInfo: {
-                    chunkSetId,
+                    chunkSetId: '',
                     chunkIndex: i,
                     totalChunks,
                     originalSize: data.length

--- a/webview_rpc_sample/package-lock.json
+++ b/webview_rpc_sample/package-lock.json
@@ -18,7 +18,8 @@
       }
     },
     "../webview_rpc_runtime_library": {
-      "version": "2.0.9",
+      "name": "app-webview-rpc",
+      "version": "2.0.10",
       "license": "MIT",
       "devDependencies": {
         "http-server": "^14.1.1",


### PR DESCRIPTION
- Replaces incremental request IDs with UUIDs to eliminate potential collisions, ensuring robust identification across multiple client/server instances
- Refactors chunk handling to associate chunk sets directly with request IDs, removing obsolete chunkSetId usage and related string concatenations for improved code clarity and efficiency
- Makes minor improvements for field declaration order and explicit interface member visibility
- Adds UniTask 2.5.10 as a dependency
- Updates documentation and changelog for accuracy

These changes enhance reliability, particularly in multi-instance scenarios, and simplify internal tracking of in-flight RPC messages.