### PR TITLE
Adds server readiness handshake to RPC framework

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -472,6 +472,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 696344747}
+  - {fileID: 929564075}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -517,7 +518,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 224179541092979990, guid: 3e10f3b6a733e441c8352020cff2f1f6, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 224179541092979990, guid: 3e10f3b6a733e441c8352020cff2f1f6, type: 3}
       propertyPath: m_AnchorMin.x
@@ -634,6 +635,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   webViewPrefab: {fileID: 696344748}
+  image: {fileID: 1144556350}
+  text: {fileID: 717926546}
+  serviceRegistrationDelay: 3
 --- !u!4 &703152729
 Transform:
   m_ObjectHideFlags: 0
@@ -649,6 +653,85 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &717926544
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 717926545}
+  - component: {fileID: 717926547}
+  - component: {fileID: 717926546}
+  m_Layer: 5
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &717926545
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 717926544}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 929564075}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 300}
+  m_SizeDelta: {x: 0, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &717926546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 717926544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 100
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Message
+--- !u!222 &717926547
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 717926544}
+  m_CullTransparentMesh: 1
 --- !u!1 &832575517
 GameObject:
   m_ObjectHideFlags: 0
@@ -698,6 +781,283 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &929564074
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 929564075}
+  - component: {fileID: 929564077}
+  - component: {fileID: 929564076}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &929564075
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 929564074}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1144556349}
+  - {fileID: 717926545}
+  m_Father: {fileID: 624682510}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &929564076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 929564074}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.30400303, g: 0.21226418, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &929564077
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 929564074}
+  m_CullTransparentMesh: 1
+--- !u!1 &944573196
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 944573197}
+  - component: {fileID: 944573199}
+  - component: {fileID: 944573198}
+  m_Layer: 5
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &944573197
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944573196}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1144556349}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &944573198
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944573196}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 100
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Send Message
+--- !u!222 &944573199
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944573196}
+  m_CullTransparentMesh: 1
+--- !u!1 &1144556348
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1144556349}
+  - component: {fileID: 1144556352}
+  - component: {fileID: 1144556351}
+  - component: {fileID: 1144556350}
+  m_Layer: 5
+  m_Name: Button (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1144556349
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1144556348}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 944573197}
+  m_Father: {fileID: 929564075}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1144556350
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1144556348}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1144556351}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1144556351
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1144556348}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1144556352
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1144556348}
+  m_CullTransparentMesh: 1
 --- !u!1 &1565210881
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/WebviewRpc/Runtime/WebViewRpcServer.cs
+++ b/Packages/WebviewRpc/Runtime/WebViewRpcServer.cs
@@ -50,6 +50,27 @@ namespace WebViewRPC
             {
                 var bytes = Convert.FromBase64String(base64);
                 var envelope = RpcEnvelope.Parser.ParseFrom(bytes);
+                
+                // Respond to ready check requests
+                if (envelope.Method == "__SYSTEM_READY_CHECK__" && envelope.IsRequest)
+                {
+                    Debug.Log($"[WebViewRpcServer] Received ready check request #{envelope.RequestId}");
+                    
+                    var responseEnvelope = new RpcEnvelope
+                    {
+                        RequestId = envelope.RequestId,
+                        IsRequest = false,
+                        Method = "__SYSTEM_READY_CHECK__",
+                        Payload = ByteString.CopyFrom(new byte[] { 1 })
+                    };
+                    
+                    var bytes2 = responseEnvelope.ToByteArray();
+                    var base64Response = Convert.ToBase64String(bytes2);
+                    _bridge.SendMessageToWeb(base64Response);
+                    
+                    Debug.Log($"[WebViewRpcServer] Sent ready check response for #{envelope.RequestId}");
+                    return;
+                }
 
                 // Check if this is a chunked message
                 if (envelope.ChunkInfo != null)

--- a/Packages/WebviewRpc/package.json
+++ b/Packages/WebviewRpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.kwanjoong.webviewrpc",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "displayName": "Webview RPC",
   "description": "The webview Remote Procedure Call bridge.",
   "unity": "2022.3",

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -817,6 +817,7 @@ PlayerSettings:
   webGLCloseOnQuit: 0
   webWasm2023: 0
   scriptingDefineSymbols:
+    Android: VUPLEX_STANDALONE
     Standalone: VUPLEX_STANDALONE
   additionalCompilerArguments: {}
   platformArchitecture: {}

--- a/webview_rpc_runtime_library/package-lock.json
+++ b/webview_rpc_runtime_library/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-webview-rpc",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-webview-rpc",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "http-server": "^14.1.1",

--- a/webview_rpc_runtime_library/package.json
+++ b/webview_rpc_runtime_library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-webview-rpc",
-  "version": "2.0.11",
+  "version": "2.1.0",
   "type": "module",
   "description": "WebView RPC provides an abstraction layer that allows communication between the App (e.g. Unity C#) and WebView (HTML, JS) using protobuf, similar to gRPC.",
   "main": "./dist/cjs/index.js",

--- a/webview_rpc_runtime_library/src/core/webview_rpc_server.js
+++ b/webview_rpc_runtime_library/src/core/webview_rpc_server.js
@@ -61,6 +61,25 @@ export class WebViewRpcServer {
         try {
             const bytes = base64ToUint8Array(base64Message);
             const envelope = decodeRpcEnvelope(bytes);
+            
+            // Respond to ready check requests
+            if (envelope.method === '__SYSTEM_READY_CHECK__' && envelope.isRequest) {
+                console.log(`[WebViewRpcServer] Received ready check request #${envelope.requestId}`);
+                
+                const responseEnvelope = {
+                    requestId: envelope.requestId,
+                    isRequest: false,
+                    method: '__SYSTEM_READY_CHECK__',
+                    payload: new Uint8Array([1])
+                };
+                
+                const responseBytes = encodeRpcEnvelope(responseEnvelope);
+                const responseBase64 = uint8ArrayToBase64(responseBytes);
+                this._bridge.sendMessage(responseBase64);
+                
+                console.log(`[WebViewRpcServer] Sent ready check response for #${envelope.requestId}`);
+                return;
+            }
 
             // Check if this is a chunked message
             if (envelope.chunkInfo) {

--- a/webview_rpc_sample/package-lock.json
+++ b/webview_rpc_sample/package-lock.json
@@ -19,7 +19,7 @@
     },
     "../webview_rpc_runtime_library": {
       "name": "app-webview-rpc",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "MIT",
       "devDependencies": {
         "http-server": "^14.1.1",

--- a/webview_rpc_sample/src/index.js
+++ b/webview_rpc_sample/src/index.js
@@ -51,10 +51,45 @@ document.addEventListener('DOMContentLoaded', () => {
         logsEl.appendChild(p);
         console.log(message);
     };
+    
+    // 극한 테스트: DOM 로드 직후 바로 요청 보내기
+    log("=== EXTREME TIMING TEST ===");
+    log("Sending request immediately after page load...");
+    
+    (async () => {
+        try {
+            const immediateReq = {
+                name: "Immediate Test from WebView",
+                longMessage: "Testing ready check mechanism",
+                repeatCount: 1
+            };
+            
+            const startTime = Date.now();
+            log(`[${new Date().toISOString()}] Sending immediate request...`);
+            
+            const resp = await helloClient.SayHello(immediateReq);
+            
+            const elapsed = Date.now() - startTime;
+            log(`[${new Date().toISOString()}] Response received after ${elapsed}ms`);
+            
+            if (resp.error) {
+                log(`Immediate test failed: ${resp.error.message}`);
+            } else if (resp.data) {
+                log(`Immediate test succeeded: ${resp.data.greeting}`);
+                log(`Unity server was ready after ${elapsed}ms`);
+            }
+            
+            log("=== END EXTREME TIMING TEST ===\n");
+        } catch (err) {
+            log(`Immediate test error: ${err.message}`);
+            log("=== END EXTREME TIMING TEST ===\n");
+        }
+    })();
 
     document.getElementById('btnSayHello').addEventListener('click', async () => {
         try {
-            log("--- Sending Hello Request ---");
+            log("--- Starting Hello Request Test ---");
+            log("Waiting for Unity server to be ready...");
             
             // Create a very long message for chunking test
             const longMessage = "A".repeat(2000) + "B".repeat(2000) + "C".repeat(2000);
@@ -187,6 +222,30 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Add config test button to the page
     document.querySelector('body').insertBefore(configTestBtn, document.getElementById('logs'));
+    
+    // Add ready check test button
+    const readyTestBtn = document.createElement('button');
+    readyTestBtn.textContent = 'Test Manual Ready Check';
+    readyTestBtn.addEventListener('click', async () => {
+        log("--- Testing Manual Ready Check ---");
+        
+        try {
+            const startTime = Date.now();
+            log("Manually waiting for Unity server to be ready (15s timeout)...");
+            
+            await rpcClient.waitForServerReady(15000); // 15 second timeout
+            
+            const elapsed = Date.now() - startTime;
+            log(`✓ Unity server became ready after ${elapsed}ms`);
+        } catch (error) {
+            log(`✗ Ready check failed: ${error.message}`);
+        }
+        
+        log("--------------------------");
+    });
+    
+    // Add ready test button to the page
+    document.querySelector('body').insertBefore(readyTestBtn, document.getElementById('logs'));
     
     // Add dispose test button
     const disposeBtn = document.createElement('button');


### PR DESCRIPTION
Introduces a robust server ready check mechanism to the RPC framework for both Unity and JavaScript runtimes.

- Implements a handshake protocol that waits for explicit server readiness before processing RPC calls, preventing race conditions where requests are sent before the server is initialized.
- Adds periodic "ready check" pings from clients, with handshake responses from servers, on both Unity (C#) and JS sides.
- Updates sample scenes and demo UIs to expose and test readiness controls, including immediate and manual ready check operations.
- Improves UX by clarifying server startup status via logs and UI, and guards against connection issues at startup.
- Bumps all package and sample versions to 2.1.0.
- Adds Android scripting define symbols for WebViewRPC.

Improves reliability and developer experience, especially under rapid startup, extreme timing, and cross-platform scenarios.