### PR TITLE
Removes verbose logging from ready check routines

### DIFF
--- a/webview_rpc_runtime_library/CHANGELOG.md
+++ b/webview_rpc_runtime_library/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2025-07-08
+
+### Changed
+- Removed unnecessary console.log statements for cleaner production output
+- Reduced verbosity of ready check logging
+
+### Fixed
+- Console output was too verbose in production environments
+
+## [2.1.0] - 2025-07-08
+
+### Added
+- Connection handshake mechanism between WebView and Unity
+- Automatic server ready detection before RPC calls
+- Configurable timeout for server ready checks (default: 10 seconds)
+- Retry mechanism with exponential backoff for connection establishment
+- `waitForServerReady()` method for manual ready state checking
+
+### Changed
+- RPC calls now automatically wait for server readiness
+- Improved error handling with `UniTask` instead of `async void` patterns
+- Better exception handling in background tasks
+- Added comprehensive logging for connection state debugging
+
+### Fixed
+- **Critical**: Fixed timing issues where RPC calls would hang indefinitely if server wasn't ready
+- Fixed race conditions when WebView loads before Unity server initialization
+- Fixed potential crashes from unhandled exceptions in ready check loops
+- Resolved issues with immediate RPC calls after page load
+
 ## [2.0.11] - 2025-07-01
 ### Fixed
 - Corrected release dates in CHANGELOG.md

--- a/webview_rpc_runtime_library/package-lock.json
+++ b/webview_rpc_runtime_library/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-webview-rpc",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-webview-rpc",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "http-server": "^14.1.1",

--- a/webview_rpc_runtime_library/package.json
+++ b/webview_rpc_runtime_library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-webview-rpc",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "description": "WebView RPC provides an abstraction layer that allows communication between the App (e.g. Unity C#) and WebView (HTML, JS) using protobuf, similar to gRPC.",
   "main": "./dist/cjs/index.js",

--- a/webview_rpc_runtime_library/src/core/webview_rpc_client.js
+++ b/webview_rpc_runtime_library/src/core/webview_rpc_client.js
@@ -33,7 +33,6 @@ export class WebViewRpcClient {
      */
     _startReadyCheck() {
         let checkCount = 0;
-        console.log('[WebViewRpcClient] Starting ready check for Unity server...');
         
         // Wrap in try-catch to prevent uncaught exceptions
         const performCheck = () => {
@@ -44,7 +43,6 @@ export class WebViewRpcClient {
                 }
                 
                 checkCount++;
-                console.log(`[WebViewRpcClient] Ready check #${checkCount} - sending ping to Unity server...`);
                 
                 const pingEnvelope = {
                     requestId: 'READY_CHECK_' + Date.now(),
@@ -195,7 +193,6 @@ export class WebViewRpcClient {
                         this._readyResolve();
                         this._readyResolve = null;
                     }
-                    console.log('Server is ready for RPC communication');
                 }
                 return;
             }

--- a/webview_rpc_runtime_library/src/core/webview_rpc_server.js
+++ b/webview_rpc_runtime_library/src/core/webview_rpc_server.js
@@ -64,7 +64,6 @@ export class WebViewRpcServer {
             
             // Respond to ready check requests
             if (envelope.method === '__SYSTEM_READY_CHECK__' && envelope.isRequest) {
-                console.log(`[WebViewRpcServer] Received ready check request #${envelope.requestId}`);
                 
                 const responseEnvelope = {
                     requestId: envelope.requestId,
@@ -77,7 +76,6 @@ export class WebViewRpcServer {
                 const responseBase64 = uint8ArrayToBase64(responseBytes);
                 this._bridge.sendMessage(responseBase64);
                 
-                console.log(`[WebViewRpcServer] Sent ready check response for #${envelope.requestId}`);
                 return;
             }
 


### PR DESCRIPTION
Cleans up console output by eliminating unnecessary debug logs during the server readiness check process for both client and server components.

This reduces noise in production environments and ensures cleaner, more focused logging, improving maintainability and usability.

Bumps package version to 2.1.1 and updates the changelog accordingly.